### PR TITLE
Don't double-add leading empty rows.

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -473,7 +473,7 @@ func readRowsFromSheet(Worksheet *xlsxWorksheet, file *File) ([]*Row, []*Col, in
 		rows[rowIndex] = makeEmptyRow()
 	}
 
-	for rowIndex := 0; rowIndex < len(Worksheet.SheetData.Row); rowIndex++ {
+	for rowIndex := minRow; rowIndex < len(Worksheet.SheetData.Row); rowIndex++ {
 		rawrow := Worksheet.SheetData.Row[rowIndex]
 		// Some spreadsheets will omit blank rows from the
 		// stored data


### PR DESCRIPTION
By adding empty rows (iterating from 0 to minRow), and then having additional logic in the main row conversion loop, we end up populating rows that shouldn't be empty with empty ones, and leaving out non-empty rows. Starting the main loop from minRow (since [0:minRow] is already populated) solves this.
